### PR TITLE
Support multiple implementation instances.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 
 .classpath
 .project
+/bin

--- a/src/main/java/com/epickrram/tool/disruptor/InvokerEventHandler.java
+++ b/src/main/java/com/epickrram/tool/disruptor/InvokerEventHandler.java
@@ -6,18 +6,28 @@ public final class InvokerEventHandler<T> implements EventHandler<ProxyMethodInv
 {
     private final T implementation;
     private final boolean isBatchListener;
+    private final boolean reset;
+
+    public InvokerEventHandler(final T implementation, boolean reset)
+    {
+        this.implementation = implementation;
+        this.reset = reset;
+        this.isBatchListener = implementation instanceof BatchListener;
+    }
 
     public InvokerEventHandler(final T implementation)
     {
-        this.implementation = implementation;
-        this.isBatchListener = implementation instanceof BatchListener;
+        this(implementation, true);
     }
 
     @Override
     public void onEvent(final ProxyMethodInvocation event, final long sequence, final boolean endOfBatch) throws Exception
     {
         event.getInvoker().invokeWithArgumentHolder(implementation, event.getArgumentHolder());
-        event.reset();
+        if (reset)
+        {
+            event.reset();
+        }
 
         if (isBatchListener && endOfBatch)
         {

--- a/src/main/java/com/epickrram/tool/disruptor/ResetHandler.java
+++ b/src/main/java/com/epickrram/tool/disruptor/ResetHandler.java
@@ -1,0 +1,14 @@
+package com.epickrram.tool.disruptor;
+
+import com.lmax.disruptor.EventHandler;
+
+public class ResetHandler implements EventHandler<ProxyMethodInvocation>
+{
+
+    @Override
+    public void onEvent(ProxyMethodInvocation event, long arg1, boolean arg2) throws Exception
+    {
+        event.reset();
+    }
+
+}

--- a/src/main/java/com/epickrram/tool/disruptor/RingBufferProxyGenerator.java
+++ b/src/main/java/com/epickrram/tool/disruptor/RingBufferProxyGenerator.java
@@ -6,4 +6,8 @@ public interface RingBufferProxyGenerator
 {
     <T> T createRingBufferProxy(final T implementation, final Class<T> definition,
                                 final Disruptor<ProxyMethodInvocation> disruptor, final OverflowStrategy overflowStrategy);
+
+    @SuppressWarnings("varargs")
+    <T> T createRingBufferProxy(final Class<T> definition, final Disruptor<ProxyMethodInvocation> disruptor,
+                                final OverflowStrategy overflowStrategy, final T... implementations);
 }

--- a/src/main/java/com/epickrram/tool/disruptor/bytecode/GeneratedRingBufferProxyGenerator.java
+++ b/src/main/java/com/epickrram/tool/disruptor/bytecode/GeneratedRingBufferProxyGenerator.java
@@ -47,6 +47,15 @@ public final class GeneratedRingBufferProxyGenerator implements RingBufferProxyG
     public <T> T createRingBufferProxy(Class<T> definition, Disruptor<ProxyMethodInvocation> disruptor,
                                        OverflowStrategy overflowStrategy, T... implementations)
     {
+        if (implementations.length < 1)
+        {
+            throw new IllegalArgumentException("Must have at least one implementation");
+        }
+        else if (implementations.length == 1)
+        {
+            return createRingBufferProxy(implementations[0], definition, disruptor, overflowStrategy);
+        }
+
         InvokerEventHandler<T>[] handlers = new InvokerEventHandler[implementations.length];
         for (int i = 0; i < implementations.length; i++)
         {

--- a/src/main/java/com/epickrram/tool/disruptor/reflect/ReflectiveRingBufferProxyGenerator.java
+++ b/src/main/java/com/epickrram/tool/disruptor/reflect/ReflectiveRingBufferProxyGenerator.java
@@ -36,6 +36,15 @@ public final class ReflectiveRingBufferProxyGenerator implements RingBufferProxy
     public <T> T createRingBufferProxy(Class<T> definition, Disruptor<ProxyMethodInvocation> disruptor,
                                        OverflowStrategy overflowStrategy, T... implementations)
     {
+        if (implementations.length < 1)
+        {
+            throw new IllegalArgumentException("Must have at least one implementation");
+        }
+        else if (implementations.length == 1)
+        {
+            return createRingBufferProxy(implementations[0], definition, disruptor, overflowStrategy);
+        }
+
         InvokerEventHandler<T>[] handlers = new InvokerEventHandler[implementations.length];
         for (int i = 0; i < implementations.length; i++)
         {


### PR DESCRIPTION
This add the ability to pass in multiple implementations for a given interface.  Each implementation will run in a separate event handler and in a separate thread.  If there are more than one implementation and additional reset handler thread will be spawned to clear out the disruptor entries after being processed.